### PR TITLE
feat: Add better support for catch-all segments

### DIFF
--- a/.changeset/funny-geckos-destroy.md
+++ b/.changeset/funny-geckos-destroy.md
@@ -1,0 +1,5 @@
+---
+"next-safe-navigation": minor
+---
+
+Add better support for Catch-all Segments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: 🧪 Run tests
-        run: pnpm run test:ci
+        run: bun run test:ci
 
       - name: ⬆️ Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ export const { routes, useSafeParams, useSafeSearchParams } = createNavigationCo
         invoiceId: z.string(),
       }),
     }),
+    shop: defineRoute('/support/[...tickets]', {
+      params: z.object({
+        tickets: z.array(z.string()),
+      }),
+    }),
+    shop: defineRoute('/shop/[[...slug]]', {
+      params: z.object({
+        // ⚠️ Remember to always set your optional catch-all segments
+        // as optional values, or add a default value to them
+        slug: z.array(z.string()).optional(),
+      }),
+    }),
   }),
 );
 ```

--- a/src/make-route-builder.spec.ts
+++ b/src/make-route-builder.spec.ts
@@ -188,7 +188,7 @@ describe('makeRouteBuilder', () => {
       it('creates a builder that replaces the path param with its value', () => {
         const builder = makeRouteBuilder('/[[...catch_all]]', {
           params: z.object({
-            catch_all: z.array(z.string()),
+            catch_all: z.array(z.string()).default([]),
           }),
         });
 

--- a/src/make-route-builder.spec.ts
+++ b/src/make-route-builder.spec.ts
@@ -161,6 +161,50 @@ describe('makeRouteBuilder', () => {
         expect(builder({ orgId: 'org_789' })).toBe('/organizations/org_789');
       });
     });
+
+    describe('when path has catch-all params', () => {
+      it('creates a builder that replaces the path param with its value', () => {
+        const builder = makeRouteBuilder('/[...catch_all]', {
+          params: z.object({
+            catch_all: z.array(z.string()),
+          }),
+        });
+
+        // @ts-expect-error no searchParams validation was defined
+        builder({ catch_all: ['channels'], search: {} });
+
+        expect(builder({ catch_all: ['channels', 'channel_123'] })).toBe(
+          '/channels/channel_123',
+        );
+
+        expect(builder.getSchemas()).toEqual({
+          params: expect.any(Object),
+          search: undefined,
+        });
+      });
+    });
+
+    describe('when path has optional catch-all params', () => {
+      it('creates a builder that replaces the path param with its value', () => {
+        const builder = makeRouteBuilder('/[[...catch_all]]', {
+          params: z.object({
+            catch_all: z.array(z.string()),
+          }),
+        });
+
+        // @ts-expect-error no searchParams validation was defined
+        builder({ catch_all: ['channels'], search: {} });
+
+        expect(builder({ catch_all: ['channels', 'channel_123'] })).toBe(
+          '/channels/channel_123',
+        );
+
+        expect(builder.getSchemas()).toEqual({
+          params: expect.any(Object),
+          search: undefined,
+        });
+      });
+    });
   });
 
   describe('for a path with route params and searchParams', () => {

--- a/src/make-route-builder.ts
+++ b/src/make-route-builder.ts
@@ -76,6 +76,19 @@ type RouteBuilderResult<
   : never;
 
 const PATH_PARAM_REGEX = /\[{1,2}([^[\]]+)]{1,2}/g;
+
+/**
+ * Remove param notation from string to only get the param name when it is a catch-all segment
+ *
+ * @example
+ * ```ts
+ * '/shop/[[...slug]]'.replace(PATH_PARAM_REGEX, (match, param) => {
+ *   //                                                    ^? '[[...slug]]'
+ *   const [sanitizedParam] = REMOVE_PARAM_NOTATION_REGEX.exec(param)
+ *   //          ^? 'slug'
+ * })
+ * ```
+ */
 const REMOVE_PARAM_NOTATION_REGEX = /[^[.].+[^\]]/;
 
 // @ts-expect-error overload signature does match the implementation,


### PR DESCRIPTION
This PR adds better support for `catch-all segments`, by allowing catch-all params to be written as `[...slug]` or `[[...slug]]` with the proper param name enforcement in the zod schema