### PR TITLE
feat: check if urlSearchParams exists using iterator instead of size

### DIFF
--- a/src/make-route-builder.ts
+++ b/src/make-route-builder.ts
@@ -173,7 +173,7 @@ export function makeRouteBuilder(
 
     const urlSearchParams = convertObjectToURLSearchParams(search);
 
-    if (urlSearchParams.size) {
+    if (!urlSearchParams.entries().next().done) {
       return [basePath, urlSearchParams.toString()].join('?');
     }
 


### PR DESCRIPTION
This resolves the issue https://github.com/lukemorales/next-safe-navigation/issues/20 I opened where older browsers don't have access to `URLSearchParams.size`. 