### PR TITLE
fix: Repair catch-all route params couldn't be mixed with other params

### DIFF
--- a/.changeset/lucky-years-change.md
+++ b/.changeset/lucky-years-change.md
@@ -1,0 +1,5 @@
+---
+"next-safe-navigation": patch
+---
+
+Fix `catch-all` params can't be mixed with other params

--- a/src/create-navigation-config.spec.ts
+++ b/src/create-navigation-config.spec.ts
@@ -149,11 +149,12 @@ describe('createNavigationConfig', () => {
       describe('when path has multiple route params', () => {
         const { routes } = createNavigationConfig((defineRoute) => ({
           organizationUser: defineRoute(
-            '/organizations/[orgId]/users/[userId]',
+            '/organizations/[orgId]/users/[userId]/[[...catch_all]]',
             {
               params: z.object({
                 orgId: z.string(),
                 userId: z.string(),
+                catch_all: z.array(z.string()).default([])
               }),
             },
           ),
@@ -168,8 +169,8 @@ describe('createNavigationConfig', () => {
           });
 
           expect(
-            routes.organizationUser({ orgId: 'org_123', userId: 'user_123' }),
-          ).toBe('/organizations/org_123/users/user_123');
+            routes.organizationUser({ orgId: 'org_123', userId: 'user_123', catch_all: ['channel_123'] }),
+          ).toBe('/organizations/org_123/users/user_123/channel_123');
         });
 
         it('exposes method to validate only params', () => {

--- a/src/create-navigation-config.spec.ts
+++ b/src/create-navigation-config.spec.ts
@@ -154,7 +154,7 @@ describe('createNavigationConfig', () => {
               params: z.object({
                 orgId: z.string(),
                 userId: z.string(),
-                catch_all: z.array(z.string()).default([])
+                catch_all: z.array(z.string()).default([]),
               }),
             },
           ),
@@ -169,7 +169,11 @@ describe('createNavigationConfig', () => {
           });
 
           expect(
-            routes.organizationUser({ orgId: 'org_123', userId: 'user_123', catch_all: ['channel_123'] }),
+            routes.organizationUser({
+              orgId: 'org_123',
+              userId: 'user_123',
+              catch_all: ['channel_123'],
+            }),
           ).toBe('/organizations/org_123/users/user_123/channel_123');
         });
 

--- a/src/make-route-builder.spec.ts
+++ b/src/make-route-builder.spec.ts
@@ -204,6 +204,58 @@ describe('makeRouteBuilder', () => {
         });
       });
     });
+
+    describe('when path has normal and catch-all params', () => {
+      it('creates a builder that replaces the path params with their value', () => {
+        const builder = makeRouteBuilder(
+          '/organization/[orgId]/c/[...catch_all]',
+          {
+            params: z.object({
+              orgId: z.string(),
+              catch_all: z.array(z.string()),
+            }),
+          },
+        );
+
+        // @ts-expect-error no searchParams validation was defined
+        builder({ catch_all: ['channels'], search: {} });
+
+        expect(
+          builder({ catch_all: ['channels', 'channel_123'], orgId: 'org_123' }),
+        ).toBe('/organization/org_123/c/channels/channel_123');
+
+        expect(builder.getSchemas()).toEqual({
+          params: expect.any(Object),
+          search: undefined,
+        });
+      });
+    });
+  });
+
+  describe('when path has normal and optional catch-all params', () => {
+    it('creates a builder that replaces the path params with their value', () => {
+      const builder = makeRouteBuilder(
+        '/organization/[orgId]/c/[[...catch_all]]',
+        {
+          params: z.object({
+            orgId: z.string(),
+            catch_all: z.array(z.string()).default([]),
+          }),
+        },
+      );
+
+      // @ts-expect-error no searchParams validation was defined
+      builder({ catch_all: ['channels'], search: {} });
+
+      expect(
+        builder({ catch_all: ['channels', 'channel_123'], orgId: 'org_123' }),
+      ).toBe('/organization/org_123/c/channels/channel_123');
+
+      expect(builder.getSchemas()).toEqual({
+        params: expect.any(Object),
+        search: undefined,
+      });
+    });
   });
 
   describe('for a path with route params and searchParams', () => {

--- a/src/make-route-builder.ts
+++ b/src/make-route-builder.ts
@@ -22,9 +22,9 @@ type Suffix = `?${string}`;
 type SafePath<Path extends string> = string extends Route ? Path : Route<Path>;
 
 type ExtractPathParams<T extends string> =
-  T extends `${string}[[...${infer Param}]]${infer Rest}` ?
+  T extends `${infer Rest}[[...${infer Param}]]` ?
     Param | ExtractPathParams<Rest>
-  : T extends `${string}[...${infer Param}]${infer Rest}` ?
+  : T extends `${infer Rest}[...${infer Param}]` ?
     Param | ExtractPathParams<Rest>
   : T extends `${string}[${infer Param}]${infer Rest}` ?
     Param | ExtractPathParams<Rest>


### PR DESCRIPTION
This PR fixes the issue of `catch_all` route params can't be mixed with others, like:

```ts
        const { routes } = createNavigationConfig((defineRoute) => ({
          organizationUser: defineRoute(
            '/organizations/[orgId]/users/[userId]/[[...catch_all]]',
            {
              params: z.object({
                orgId: z.string(),
                userId: z.string(),
                catch_all: z.array(z.string()).default([])
              }),
            },
          ),
        }));
```
